### PR TITLE
Fix logical error in SystemConsistency class

### DIFF
--- a/src/chapter05/consistency.js
+++ b/src/chapter05/consistency.js
@@ -2,7 +2,7 @@ class SystemConsistency {
     static threeWayMerge(current, previous, next) {
         var previousToCurrent = diff(previous, current); // <1> 
         var previousToNext = diff(previous, next);
-        if(havePathInCommon(previousToCurrent, previousToNext)) {
+        if(!havePathInCommon(previousToCurrent, previousToNext)) {
             return _.merge(current, previousToNext);
         }
         throw "Conflicting concurrent mutations.";


### PR DESCRIPTION
- e3d7543ca60b1ee621844da5138096a061f466c6: Fix the wrong condition in the `threeWayMerge`.

## Related issues

- https://github.com/viebel/data-oriented-programming/issues/19